### PR TITLE
pileup name lost

### DIFF
--- a/lib/bio/db/sam.rb
+++ b/lib/bio/db/sam.rb
@@ -2,6 +2,7 @@ require 'bio/db/sam/library'
 require 'bio/db/sam/bam'
 require 'bio/db/sam/faidx'
 require 'bio/db/sam/sam'
+require 'bio/db/sam/pileup'
 
 module LibC
   extend FFI::Library


### PR DESCRIPTION
patch for naming of pileup class, will be fine now... 
