### PR TITLE
require bio/db/pileup and ire 'bio/db/vcf' by default.

### DIFF
--- a/lib/bio-samtools.rb
+++ b/lib/bio-samtools.rb
@@ -1,2 +1,4 @@
 require 'ffi'
 require 'bio/db/sam'
+require 'bio/db/pileup'
+require 'bio/db/vcf'


### PR DESCRIPTION
Otherwise I get:

```
> pile = Bio::DB::Pileup.new
NameError: uninitialized constant Bio::DB::Pileup
```
