### PR TITLE
regex change (for issue #18)

### DIFF
--- a/lib/bio/db/sam/library.rb
+++ b/lib/bio/db/sam/library.rb
@@ -16,9 +16,9 @@ module Bio
             'dll'
           else
             case RUBY_DESCRIPTION
-            when /darwin.*java/
+            when /jruby.*darwin/
               '1.dylib'
-            when /linux.*java/
+            when /jruby.*linux/
             'so.1'
             end
           end


### PR DESCRIPTION
Change in the regex to determine native library extension when loaded from JRuby (since RUBY_DESCRIPTION changed in JRuby 1.7.0).
