### PR TITLE
Replace 'curses' with 'ncurses' for building samtools.

### DIFF
--- a/bio-samtools.gemspec
+++ b/bio-samtools.gemspec
@@ -154,6 +154,7 @@ Gem::Specification.new do |s|
     "doc/tutorial.html",
     "doc/tutorial.pdf",
     "ext/Makefile-bioruby.patch",
+    "ext/Makefile-suse.patch",
     "ext/mkrf_conf.rb",
     "lib/bio-samtools.rb",
     "lib/bio/.DS_Store",

--- a/ext/Makefile-suse.patch
+++ b/ext/Makefile-suse.patch
@@ -1,0 +1,11 @@
+--- Makefile	2013-12-10 14:06:29.868639418 +0000
++++ Makefile.opensuse	2013-12-10 14:06:56.548222174 +0000
+@@ -13,7 +13,7 @@
+ INCLUDES=	-I.
+ SUBDIRS=	. bcftools misc
+ LIBPATH=
+-LIBCURSES=	-lcurses # -lXCurses
++LIBCURSES=	-lncurses # -lXCurses
+ 
+ .SUFFIXES:.c .o
+ 

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -37,6 +37,8 @@ task :compile do
   sh "tar xvfj #{SamToolsFile}"
   cd("samtools-#{Version}") do
     sh "patch < ../Makefile-bioruby.patch"
+    # This patch replace CURSES lib with NCURSES which it is the only one available in OpenSUSE
+    sh "patch < ../Makefile-suse.patch"
     case Config::CONFIG['host_os']
       when /linux/
         #sh "CFLAGS='-g -Wall -O2 -fPIC' make -e"


### PR DESCRIPTION
samtools 0.18 does not compile under openSUSE since ncurses is not considered a drop-in replacement for curses on that distribution.
This commit applies a patch to the samtools Makefile in order to explicitly link against ncurses instead of curses.
