### PR TITLE
remove Gemfile.lock from gemspec

### DIFF
--- a/bio-samtools.gemspec
+++ b/bio-samtools.gemspec
@@ -223,6 +223,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<ffi>, [">= 0"])
+    s.add_dependency(%q<systemu>, [">= 0"])
     s.add_dependency(%q<bio>, [">= 1.4.2"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])


### PR DESCRIPTION
Hi,
   The current version have following warning when try to add bundle from git

If you need to use this package without installing it from a gem repository, please contact ilpuccio.febo@gmail.com and ask them to modify their .gemspec so it can work with `gem build`.
The validation message from Rubygems was:
  ["Gemfile.lock"] are not files

Remove Gemfile.lock from gemspec is help.

Best,
-Jirapong 
