### PR TITLE
Open uri redirections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 #   gem "activesupport", ">= 2.3.5"
 gem "bio-svgenes", ">= 0.4.1"
 gem "bio", ">= 1.4.2"
+gem 'open_uri_redirections'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -7,7 +7,7 @@ require 'rake/clean'
 URL = "http://sourceforge.net/projects/samtools/files/samtools/0.1.19/samtools-0.1.19.tar.bz2/download"
 
 task :download do
-  open(URL) do |uri|
+  open(URL) :allow_redirections => :all do |uri|
     File.open("samtools-0.1.19.tar.bz2",'wb') do |fout|
       fout.write(uri.read)
     end #fout 

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,5 +1,6 @@
 require 'rbconfig'
 require 'open-uri'
+require 'open-uri-redirections'
 require 'fileutils'
 include FileUtils::Verbose
 require 'rake/clean'

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -7,13 +7,13 @@ require 'rake/clean'
 URL = "http://sourceforge.net/projects/samtools/files/samtools/0.1.19/samtools-0.1.19.tar.bz2/download"
 
 task :download do
-  open(URL) :allow_redirections => :all do |uri|
+  open(URL, :allow_redirections => :all) do |uri|
     File.open("samtools-0.1.19.tar.bz2",'wb') do |fout|
       fout.write(uri.read)
-    end #fout 
+    end #fout
   end #uri
 end
-    
+
 task :compile do
   sh "tar xvfj samtools-0.1.19.tar.bz2"
   cd("samtools-0.1.19") do
@@ -21,14 +21,14 @@ task :compile do
     # This patch replace CURSES lib with NCURSES which it is the only one available in OpenSUSE
     sh "patch < ../Makefile-suse.patch"
     sh "make"
-    cp('samtools', "/Users/ramirezr/Documents/public_code/git_merge/bioruby-samtools/ext/../lib/bio/db/sam/external")          
+    cp('samtools', "/Users/ramirezr/Documents/public_code/git_merge/bioruby-samtools/ext/../lib/bio/db/sam/external")
   end #cd
   cd("samtools-0.1.19/bcftools") do
     sh "make"
     cp('bcftools', "/Users/ramirezr/Documents/public_code/git_merge/bioruby-samtools/ext/../lib/bio/db/sam/external")
   end
 end
-  
+
 task :clean do
   cd("samtools-0.1.19") do
     sh "make clean"
@@ -38,4 +38,3 @@ task :clean do
 end
 
 task :default => [:download, :compile, :clean]
-  

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,6 +1,6 @@
 require 'rbconfig'
 require 'open-uri'
-require 'open-uri-redirections'
+require 'open_uri_redirections'
 require 'fileutils'
 include FileUtils::Verbose
 require 'rake/clean'

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -26,7 +26,7 @@ require 'rake/clean'
 URL = "#{url}"
 
 task :download do
-  open(URL) :allow_redirections => :all do |uri|
+  open(URL, :allow_redirections => :all) do |uri|
     File.open("#{SamToolsFile}",'wb') do |fout|
       fout.write(uri.read)
     end #fout

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,4 +1,4 @@
-#(c) Copyright 2011 Raoul Bonnal. All Rights Reserved. 
+#(c) Copyright 2011 Raoul Bonnal. All Rights Reserved.
 
 # create Rakefile for shared library compilation
 
@@ -26,13 +26,13 @@ require 'rake/clean'
 URL = "#{url}"
 
 task :download do
-  open(URL) do |uri|
+  open(URL) :allow_redirections => :all do |uri|
     File.open("#{SamToolsFile}",'wb') do |fout|
       fout.write(uri.read)
-    end #fout 
+    end #fout
   end #uri
 end
-    
+
 task :compile do
   sh "tar xvfj #{SamToolsFile}"
   cd("samtools-#{Version}") do
@@ -40,14 +40,14 @@ task :compile do
     # This patch replace CURSES lib with NCURSES which it is the only one available in OpenSUSE
     sh "patch < ../Makefile-suse.patch"
     sh "make"
-    cp('samtools', "#{path_external}")          
+    cp('samtools', "#{path_external}")
   end #cd
   cd("samtools-#{Version}/bcftools") do
     sh "make"
     cp('bcftools', "#{path_external}")
   end
 end
-  
+
 task :clean do
   cd("samtools-#{Version}") do
     sh "make clean"
@@ -57,7 +57,7 @@ task :clean do
 end
 
 task :default => [:download, :compile, :clean]
-  
+
 RAKE
-  
+
 end

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -19,6 +19,7 @@ File.open(File.join(path,"Rakefile"),"w") do |rakefile|
 rakefile.write <<-RAKE
 require 'rbconfig'
 require 'open-uri'
+require 'open-uri-redirections'
 require 'fileutils'
 include FileUtils::Verbose
 require 'rake/clean'

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -19,7 +19,7 @@ File.open(File.join(path,"Rakefile"),"w") do |rakefile|
 rakefile.write <<-RAKE
 require 'rbconfig'
 require 'open-uri'
-require 'open-uri-redirections'
+require 'open_uri_redirections'
 require 'fileutils'
 include FileUtils::Verbose
 require 'rake/clean'


### PR DESCRIPTION
Fix for the following error on installation, caused by a redirect to https on the sourceforge link (must be a recent thing as always worked fine for me before). This gem allows a workaround, but a stable link would also fix it I guess, if that's possible.

https://github.com/open-uri-redirections/open_uri_redirections

Thanks for writing this gem!

```
rake aborted!
redirection forbidden: http://sourceforge.net/projects/samtools/files/samtools/0.1.19/samtools-0.1.19.tar.bz2/download -> https://sourceforge.net/projects/samtools/files/samtools/0.1.19/samtools-0.1.19.tar.bz2/download

Tasks: TOP => default => download
(See full trace by running task with --trace)

rake failed, exit code 1
```